### PR TITLE
consolidated dragon states

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,33 +4,31 @@
 
 package frc.robot;
 
+import com.pathplanner.lib.auto.AutoBuilder;
+
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import frc.robot.subsystems.AlgaeIntake;
-import frc.robot.subsystems.Dragon;
-import frc.robot.subsystems.CoralIntake;
-import frc.robot.Constants.LimelightConstants;
-import frc.robot.Constants.OIConstants;
-import frc.robot.commands.AlignToCoral;
-import frc.robot.commands.AlignToProcessor;
-import frc.robot.subsystems.DriveSubsystem;
-import frc.robot.subsystems.Elevator;
-import frc.robot.subsystems.superstructure.StateMachine;
-import frc.robot.subsystems.superstructure.Superstructure;
-import frc.robot.subsystems.superstructure.StateMachine.State;
-import frc.robot.subsystems.Limelight.Align;
-import frc.robot.subsystems.Limelight;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-
-
-import com.pathplanner.lib.auto.AutoBuilder;
+import frc.robot.Constants.LimelightConstants;
+import frc.robot.Constants.OIConstants;
+import frc.robot.commands.AlignToCoral;
+import frc.robot.subsystems.AlgaeIntake;
+import frc.robot.subsystems.CoralIntake;
+import frc.robot.subsystems.Dragon;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.Elevator;
+import frc.robot.subsystems.Limelight;
+import frc.robot.subsystems.Limelight.Align;
+import frc.robot.subsystems.superstructure.StateMachine;
+import frc.robot.subsystems.superstructure.StateMachine.State;
+import frc.robot.subsystems.superstructure.Superstructure;
 
 /*
  * This class is where the bulk of the robot should be declared.  Since Command-based is a
@@ -119,7 +117,7 @@ public class RobotContainer {
 
     m_driverController
       .leftTrigger(OIConstants.kTriggerButtonThreshold)
-      .onTrue(m_stateMachine.algaeIntakeSelectCommand(State.EXTAKE))
+      .onTrue(m_stateMachine.algaeIntakeSelectCommand(State.SCORE))
       .onFalse(m_stateMachine.algaeIntakeSelectCommand(State.STOW));
 
     m_driverController
@@ -129,8 +127,7 @@ public class RobotContainer {
 
 
     m_driverController.leftBumper()
-      .onTrue(m_stateMachine.extakeCoral())
-      .onFalse(m_stateMachine.stowCoralIntake());
+      .onTrue(m_superstructure.scoreCoral());
 
     // Force Actions
     m_driverController.povLeft()
@@ -143,13 +140,12 @@ public class RobotContainer {
     
     // Stages
     L1Button.onTrue(m_stateMachine.moveToLevel(State.L1));
-    L2Button.onTrue(m_stateMachine.moveToLevel(State.L2));
+    L2Button.onTrue(m_stateMachine.moveToLevel(State.L2)); 
     L3Button.onTrue(m_stateMachine.moveToLevel(State.L3));
     L4Button.onTrue(m_stateMachine.moveToLevel(State.L4));
     stowButton.onTrue(m_stateMachine.stowElevator());
     handoffButton.onTrue(m_stateMachine.coralHandoff());
-
-    coralStationButton.onTrue(m_superstructure.scoreCoral());
+    coralStationButton.onTrue(m_coralIntake.intakeCommand());
 
 
  

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -142,17 +142,16 @@ public class RobotContainer {
     m_driverController.start().onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading()));
     
     // Stages
-    L1Button.onTrue(m_stateMachine.scoreLevel(State.L1));
-    L2Button.onTrue(m_stateMachine.scoreLevel(State.L2));
-    L3Button.onTrue(m_stateMachine.scoreLevel(State.L3));
-    L4Button.onTrue(m_stateMachine.scoreLevel(State.L4));
+    L1Button.onTrue(m_stateMachine.moveToLevel(State.L1));
+    L2Button.onTrue(m_stateMachine.moveToLevel(State.L2));
+    L3Button.onTrue(m_stateMachine.moveToLevel(State.L3));
+    L4Button.onTrue(m_stateMachine.moveToLevel(State.L4));
     stowButton.onTrue(m_stateMachine.stowElevator());
     handoffButton.onTrue(m_stateMachine.coralHandoff());
 
-    coralStationButton.onTrue(m_coralIntake.intakeCommand());
+    coralStationButton.onTrue(m_superstructure.scoreCoral());
 
-    m_driverController.leftBumper()
-    .whileTrue(m_stateMachine.coralHandoff());
+
  
   }
 

--- a/src/main/java/frc/robot/subsystems/Dragon.java
+++ b/src/main/java/frc/robot/subsystems/Dragon.java
@@ -105,23 +105,18 @@ private final MechanismLigament2d m_DragonMech2D =
               break;
             case HANDOFF:
               pivotCurrentTarget = PivotSetpoints.kHandoff;
-              setRollerPower(DragonConstants.endEffectorSpeeds.kIntakeSpeed);
               break;
             case L1:
               pivotCurrentTarget = PivotSetpoints.kLevel1;
-              setRollerPower(DragonConstants.endEffectorSpeeds.kExtakeSpeed);
               break;
             case L2:
               pivotCurrentTarget = PivotSetpoints.kLevel2;
-              setRollerPower(DragonConstants.endEffectorSpeeds.kExtakeSpeed);
               break;
             case L3:
               pivotCurrentTarget = PivotSetpoints.kLevel3;
-              setRollerPower(DragonConstants.endEffectorSpeeds.kExtakeSpeed);
               break;
             case L4:
               pivotCurrentTarget = PivotSetpoints.kLevel4;
-              setRollerPower(DragonConstants.endEffectorSpeeds.kExtakeSpeed);
               break;
           }}),
           new InstantCommand(() -> moveToSetpoint()));

--- a/src/main/java/frc/robot/subsystems/superstructure/StateMachine.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/StateMachine.java
@@ -103,7 +103,7 @@ public class StateMachine extends SubsystemBase {
     );
   }
 
-  public Command scoreLevel(State level) {
+  public Command moveToLevel(State level) {
     return new SequentialCommandGroup(
       dragonSelectCommand(State.STOW), 
       elevatorSelectCommand(level),
@@ -150,6 +150,8 @@ public class StateMachine extends SubsystemBase {
       coralIntakeSelectCommand(State.HANDOFF)
     );
   }
+
+
 
 
 


### PR DESCRIPTION
added a button for the driver to physcially score the coral
handoff is still manual rn so that is also doesn't require automation from dragon itself