### PR TITLE
Optimize dragon movement and add parallel commands

### DIFF
--- a/src/main/java/frc/robot/subsystems/StateMachine.java
+++ b/src/main/java/frc/robot/subsystems/StateMachine.java
@@ -109,7 +109,7 @@ public class StateMachine extends SubsystemBase {
       m_coralIntake.intakeReady().until(m_coralIntake::atSetpoint)
           .alongWith(m_algaeIntake.stow().until(m_algaeIntake::atSetpoint))
           .alongWith(
-              m_dragon.stow().until(m_dragon::atSetpoint)
+            stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
                   .andThen(m_elevator.moveToHandoff().until(m_elevator::atSetpoint))
                   .andThen(m_dragon.handoffReady().until(m_dragon::atSetpoint)))
           .alongWith(disableManualOverride())
@@ -123,11 +123,15 @@ public class StateMachine extends SubsystemBase {
 
   /* Coral intake, dragon, and elevator commands */
 
+  private Command stowDragonIfElevatorNotAtSetpoint() {
+    return m_dragon.stow().onlyIf(() -> !m_elevator.atSetpoint());
+  }
+
   private Command idleSequence() {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return (stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToHandoff().until(m_elevator::atSetpoint))
-        .andThen(m_dragon.handoffReady().until(m_dragon::atSetpoint))
-        .andThen(m_coralIntake.intakeReady().until(m_coralIntake::atSetpoint))
+        .andThen(m_dragon.handoffReady().until(m_dragon::atSetpoint)))
+        .alongWith(m_coralIntake.intakeReady().until(m_coralIntake::atSetpoint))
         .beforeStarting(() -> m_state = State.IDLE);
   }
 
@@ -150,32 +154,25 @@ public class StateMachine extends SubsystemBase {
   }
 
   private Command handoffSequence() {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return (stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToHandoff().until(m_elevator::atSetpoint))
-        .andThen(m_dragon.handoff()
-            .until(m_dragon::atSetpoint))
-        .andThen(m_coralIntake.handoff().until(() -> m_coralIntake.atSetpoint()
-            && m_dragon.isCoralOnDragon() && !m_coralIntake.isLoaded()))
-        .andThen(m_coralIntake.intakeReady().until(m_coralIntake::atSetpoint))
-        .andThen(new SelectCommand<ElevatorSetpoint>(Map.ofEntries(
-            Map.entry(ElevatorSetpoint.POOP, setL1()),
-            Map.entry(ElevatorSetpoint.L2, setL2()),
-            Map.entry(ElevatorSetpoint.L3, setL3()),
-            Map.entry(ElevatorSetpoint.L4, setL4()),
-            Map.entry(ElevatorSetpoint.HANDOFF, dragonStandbySequence()),
-            Map.entry(ElevatorSetpoint.STOW, dragonStandbySequence())), () -> m_elevator.getSetpoint()))
+        .andThen(m_dragon.handoff().until(m_dragon::atSetpoint)))
+        .alongWith(m_coralIntake.handoffReady().until(m_coralIntake::atSetpoint))
+        .andThen(m_coralIntake.handoff().until(() -> m_dragon.isCoralOnDragon() && !m_coralIntake.isLoaded()))
+        .andThen(dragonStandbySequence()
+          .alongWith(m_coralIntake.intakeReady().until(m_coralIntake::atSetpoint)))
         .beforeStarting(() -> m_state = State.HANDOFF);
   }
 
   private Command dragonStandbySequence() {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToStow().until(m_elevator::atSetpoint))
         .andThen(m_dragon.scoreStandby().until(m_dragon::atSetpoint))
         .beforeStarting(() -> m_state = State.DRAGON_STANDBY);
   }
 
   private Command scoreReadySequence(ScoreLevel level) {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToLevel(elevatorMap.get(level)).until(m_elevator::atSetpoint))
         .andThen(m_dragon.scoreReadyLevel(dragonMap.get(level)).until(m_dragon::atSetpoint))
         .beforeStarting(() -> m_state = State.DRAGON_READY);
@@ -199,18 +196,18 @@ public class StateMachine extends SubsystemBase {
   }
 
   private Command poopStandbySequence() {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return (stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToHandoff().until(m_elevator::atSetpoint))
-        .andThen(m_coralIntake.poopStandby().until(m_coralIntake::atSetpoint))
-        .andThen(m_dragon.handoffReady().until(m_dragon::atSetpoint))
+        .andThen(m_dragon.handoffReady().until(m_dragon::atSetpoint)))
+        .alongWith(m_coralIntake.poopStandby().until(m_coralIntake::atSetpoint))
         .beforeStarting(() -> m_state = State.POOP_STANDBY);
   }
 
   private Command poopReadySequence() {
-    return m_dragon.stow().until(m_dragon::atSetpoint)
+    return (stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
         .andThen(m_elevator.moveToPoop().until(m_elevator::atSetpoint))
-        .andThen(m_coralIntake.poopReady().until(m_coralIntake::atSetpoint))
-        .andThen(m_dragon.poopReady().until(m_dragon::atSetpoint))
+        .andThen(m_dragon.poopReady().until(m_dragon::atSetpoint)))
+        .alongWith(m_coralIntake.poopReady().until(m_coralIntake::atSetpoint))
         .beforeStarting(() -> m_state = State.POOP_READY);
   }
 
@@ -347,10 +344,11 @@ public class StateMachine extends SubsystemBase {
   /* Climber commands */
 
   private Command climbSequence() {
-    return m_algaeIntake.climb().alongWith(m_coralIntake.climb()).alongWith(m_dragon.climb())
-        .alongWith(m_elevator.moveToStow())
-        .until(() -> m_algaeIntake.atSetpoint() && m_coralIntake.atSetpoint() && m_dragon.atSetpoint()
-            && m_elevator.atSetpoint());
+    return m_algaeIntake.climb().until(m_algaeIntake::atSetpoint)
+        .alongWith(m_coralIntake.climb().until(m_coralIntake::atSetpoint))
+        .alongWith(stowDragonIfElevatorNotAtSetpoint().until(m_dragon::atSetpoint)
+            .andThen(m_elevator.moveToStow().until(m_elevator::atSetpoint))
+            .andThen(m_dragon.climb().until(m_dragon::atSetpoint)));
   }
 
   public Command deployClimber() {


### PR DESCRIPTION
- Only stows dragon if elevator is not at the desired setpoint to avoid unnecessary stow transition
- Allows dragon/elevator commands to run parallel with coral intake commands
- All current unit tests pass, but may need to add more