### PR TITLE
Add zero elevator button fail-safe

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -243,6 +243,8 @@ public class RobotContainer {
       loadCoralButton
           .onTrue(new InstantCommand(() -> m_coralIntake.setLoadedTrue()))
           .onFalse(new InstantCommand(() -> m_coralIntake.setLoadedFalse()));
+    } else {
+      coralOnDragonButton.onTrue(new InstantCommand(() -> m_elevator.zeroElevator()));
     }
 
     overrideStateMachineButton

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -152,6 +152,10 @@ public class Elevator extends SubsystemBase {
     }
   }
 
+  public void zeroElevator() {
+    elevatorEncoder.setPosition(0);
+  }
+
   public boolean atSetpoint() {
     if (Robot.isSimulation()) {
       return true;


### PR DESCRIPTION
We realized that the elevator homing sequence was not finishing, causing the unmoving elevator issue. The elevator was not zeroed and constantly moving downward due to the limit switch not being pressed. If the wiring issue ever comes up again we could use this button.